### PR TITLE
Fix lambda error handling and add unit test

### DIFF
--- a/ebs_snapshot_inspection.py
+++ b/ebs_snapshot_inspection.py
@@ -109,6 +109,7 @@ def lambda_handler(event, context):
                 logger.error(f"Failed to send Slack message. Status code: {response.status}, Response: {response.data}")
     except Exception as e:
         logger.error(f"Error processing snapshots: {str(e)}")
+        raise
 
 def get_instance_name(ec2, volume_id):
     try:

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from types import ModuleType
+from unittest import mock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+# Provide a minimal dummy boto3 module so that the module under test imports
+# without requiring the real package.
+dummy_boto3 = ModuleType("boto3")
+dummy_boto3.client = lambda *args, **kwargs: None
+sys.modules.setdefault("boto3", dummy_boto3)
+
+dummy_urllib3 = ModuleType("urllib3")
+dummy_urllib3.PoolManager = lambda *args, **kwargs: None
+sys.modules.setdefault("urllib3", dummy_urllib3)
+
+import ebs_snapshot_inspection
+
+
+def test_lambda_handler_reraises_exception():
+    # Force boto3.client to raise an error to trigger the exception path
+    with mock.patch('boto3.client', side_effect=Exception("boom")):
+        with pytest.raises(Exception):
+            ebs_snapshot_inspection.lambda_handler({}, {})


### PR DESCRIPTION
## Summary
- raise exception in `lambda_handler` after logging
- add unit test ensuring exception is re-raised when boto3 client fails

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849917da0bc83218ec371ee9d809687