### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ SEND_SLACK_MESSAGE = True  # Boolean to enable/disable Slack notification
 
 # S3 bucket and key for storing CSV output
 S3_BUCKET = 'verato-snapshot-inspection'  # Replace with your S3 bucket name
-S3_KEY = 'old_snapshots.csv'  # Replace with your desired S3 key (file name)
+S3_KEY = 'old_snapshots.csv'  # Replace with your desired S3 key (filename)
 
 # Slack configuration
 SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/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'  # Replace with your Slack webhook URL


### PR DESCRIPTION
## Summary
- fix small typo in README example configuration

## Testing
- `python -m py_compile ebs_snapshot_inspection.py`


------
https://chatgpt.com/codex/tasks/task_e_6849916cac548321a6c8e3a4df35e066